### PR TITLE
fix error in update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,7 @@ cd "$DEST" || exit
 
 declare -A SITES
 SITES["amazon"]="https://www.amazon.com/s?k=shirt+without+stripes"
-SITES["bing"]="https://www.bing.com/images/search?q=shirts+without+stripes"
+SITES["bing"]="https://www.bing.com/images/search?q=shirt+without+stripes"
 SITES["google"]="https://www.google.com/search?q=shirt+without+stripes&tbm=isch"
 
 for COMPANY in "${!SITES[@]}"; do


### PR DESCRIPTION
The `bing` site would fetch results for `shirts without stripes` instead of `shirt without stripes`. This would result in an erroneous benchmark